### PR TITLE
Dockerfile changes for redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,16 @@ QuantumBlack questions for platform team
   server is started
   
   
+#Solution:
+README:
+
+The ubuntu:latest tag points to the "latest LTS", since that's the version recommended for general use. We can specify the exact version in this case as Ubuntu 18.04
+
+The problem states - that accepts port config from environment variable when server is started,
+which is a bit counterintuitive. If the question means that during the build it can take environment vars that makes sense, because on a docker start, there is no environment variables allowed.
+
+So I made an assumption that its is during docker run since that allows env vars to be passed.
+
+Memory and port being passed via docker run
+docker run -e "REDIS_PORT=6379" -e "MAX_MEMORY=2gb" -d redis
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # QuantumBlack
 QuantumBlack questions for platform team
+
+### Write a Dockerfile for redis
+* That uses the latest Ubuntu LTS Docker image as its base
+* That accepts port configuration from an environment variable when the server
+  is started
+* That accepts memory limit configuration from an environment variable when the
+  server is started
+  
+  

--- a/redis_dockerfile
+++ b/redis_dockerfile
@@ -1,0 +1,14 @@
+# author igautam1711@gmail.com
+# to build:
+# docker build -t redis .
+# to change port or max memory when starting use:
+# docker run -e "REDIS_PORT=6379" -e "MAX_MEMORY=2gb" -d redis
+
+#The ubuntu:latest tag points to the "latest LTS", since that's the version recommended for general use. We can specify the exact version in this case as Ubuntu 18.04 
+
+FROM ubuntu:latest
+
+RUN apt update
+RUN apt install -y redis-server
+
+CMD sed -i.bak "s:# maxmemory <bytes>:maxmemory $MAX_MEMORY:g" etc/redis/redis.conf && sed -i.bak s/6379/$REDIS_PORT/g etc/redis/redis.conf && sed -i.bak "s:daemonize yes:daemonize no:g" etc/redis/redis.conf && sed -i.bak s/::1//g etc/redis/redis.conf && redis-server /etc/redis/redis.conf


### PR DESCRIPTION
#Problem:

### Write a Dockerfile for redis
* That uses the latest Ubuntu LTS Docker image as its base
* That accepts port configuration from an environment variable when the server
  is started
* That accepts memory limit configuration from an environment variable when the
  server is started


#Solution:
README:
* The ubuntu:latest tag points to the "latest LTS", since that's the version recommended for general use. We can specify the exact version in this case as Ubuntu 18.04 

* The problem states -  that accepts port config from environment variable when server is started,
which is a bit counterintuitive. If the question means that during the build it can take environment vars that makes sense, because on a docker start, there is no environment variables allowed.

So I made an assumption that its is during docker run since that allows env vars to be passed.

* Memory and port being passed via docker run
docker run -e "REDIS_PORT=6379" -e "MAX_MEMORY=2gb" -d redis
